### PR TITLE
JobProxy - add missing return

### DIFF
--- a/src/Entity/JobProxy.php
+++ b/src/Entity/JobProxy.php
@@ -586,7 +586,7 @@ class JobProxy extends AbstractIdentifiableModificationDateAwareEntity implement
      */
     public function getAttachedEntity($key)
     {
-        $this->job->getAttachedEntity($key);
+        return $this->job->getAttachedEntity($key);
     }
 
     /**
@@ -606,7 +606,7 @@ class JobProxy extends AbstractIdentifiableModificationDateAwareEntity implement
      */
     public function hasAttachedEntity($key)
     {
-        $this->job->hasAttachedEntity($key);
+        return $this->job->hasAttachedEntity($key);
     }
 
     /**


### PR DESCRIPTION
Das return hat bei 2 Methoden gefehlt. Dadurch wird immer null zurückgeliefert. 